### PR TITLE
Add 'release' target

### DIFF
--- a/makefile
+++ b/makefile
@@ -28,3 +28,11 @@ push:
 # Don't generate an error if the image does not exist
 clean:
 	-docker rmi $(TAG) $(TAG)-java
+
+# Generate a make failure if the VERSION string contains "-<some letters>"
+verifyVersion:
+	@verifyVersion.sh $(VERSION)
+
+# Do not release if the image version is invalid
+# This target is intended for use when trying to build/publish images from the master branch
+release: verifyVersion clean build

--- a/makefile
+++ b/makefile
@@ -31,8 +31,13 @@ clean:
 
 # Generate a make failure if the VERSION string contains "-<some letters>"
 verifyVersion:
-	@verifyVersion.sh $(VERSION)
+	@./verifyVersion.sh $(VERSION)
+
+# Generate a make failure if the image(s) already exist
+verifyImage:
+	@./verifyImage.sh $(TAG)
+	@./verifyImage.sh $(TAG)-java
 
 # Do not release if the image version is invalid
 # This target is intended for use when trying to build/publish images from the master branch
-release: verifyVersion clean build
+release: verifyVersion verifyImage clean build push

--- a/makefile
+++ b/makefile
@@ -35,8 +35,8 @@ verifyVersion:
 
 # Generate a make failure if the image(s) already exist
 verifyImage:
-	@./verifyImage.sh $(TAG)
-	@./verifyImage.sh $(TAG)-java
+	@./verifyImage.sh zenoss/$(IMAGENAME) $(VERSION)
+	@./verifyImage.sh zenoss/$(IMAGENAME) $(VERSION)-java
 
 # Do not release if the image version is invalid
 # This target is intended for use when trying to build/publish images from the master branch

--- a/verifyImage.sh
+++ b/verifyImage.sh
@@ -11,7 +11,7 @@ fi
 #     are that (A) it lists all tags, and (B) does not require authentication.
 #
 echo "Checking for $1:$2"
-curl --silent https://registry.hub.docker.com/v1/repositories/$1/tags | grep name | grep $2 >/dev/null
+curl --silent https://registry.hub.docker.com/v1/repositories/$1/tags | grep "\"name\": \"${2}\"" >/dev/null
 
 if [ $? -eq 0 ]; then
 	echo "ERROR: Docker image $1:$2 already exists"

--- a/verifyImage.sh
+++ b/verifyImage.sh
@@ -1,14 +1,20 @@
 #!/bin/bash
 
-if [ $# -ne 1 ]; then
-	echo "ERROR: invalid argument count. Got $# arguments; should be exactly 1"
+if [ $# -ne 2 ]; then
+	echo "ERROR: invalid argument count. Got $# arguments; should be exactly 2"
 	exit 1
 fi
 
-echo "Pulling $1"
-docker pull $1
+#
+# Note that the "/v1/repositories" API on docker hub is not necessarily a publicly documented
+#     API (despite the fact that it's referenced in several StackOverflow posts). The main advantages
+#     are that (A) it lists all tags, and (B) does not require authentication.
+#
+echo "Checking for $1:$2"
+curl --silent https://registry.hub.docker.com/v1/repositories/$1/tags | grep name | grep $2 >/dev/null
 
 if [ $? -eq 0 ]; then
-	echo "ERROR: Docker image $1 already exists"
+	echo "ERROR: Docker image $1:$2 already exists"
 	exit 1
 fi
+echo "Docker image $1:$2 does not exist"

--- a/verifyImage.sh
+++ b/verifyImage.sh
@@ -5,11 +5,10 @@ if [ $# -ne 1 ]; then
 	exit 1
 fi
 
-echo "${1}" | grep "[-\_][a-zA-Z]*" >/dev/null
+echo "Pulling $1"
+docker pull $1
 
 if [ $? -eq 0 ]; then
-	echo "VERSION=${1} is NOT ok"
+	echo "ERROR: Docker image $1 already exists"
 	exit 1
-else
-	echo "VERSION=${1} ok"
 fi

--- a/verifyVersion.sh
+++ b/verifyVersion.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [ $# -ne 1 ]; then
+	echo "ERROR: invalid argument count. Got $# arguments; should be exactly 1"
+	exit 1
+fi
+
+echo "${1}" | grep "\-[a-zA-Z]*" >/dev/null
+
+if [ $? -eq 0 ]; then
+	echo "VERSION=${1} is NOT ok"
+	exit 1
+else
+	echo "VERSION=${1} ok"
+fi


### PR DESCRIPTION
Add 'release' target that verifies the image version is valid before releasing.  Basically, a little insurance to catch mistakes in treating the VERSION string, admittedly only catches problems after they have been merged to master, but at least we will not publish it accidentally.