### PR TITLE
Explicitly set TERM in root's .bashrc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,3 +57,6 @@ RUN wget -q https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 -
 
 # Add symlink for vim
 RUN ln -s /usr/bin/vi /usr/bin/vim
+
+# Add TERM=xterm to /root/.bashrc
+RUN echo "export TERM=xterm" >> /root/.bashrc


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-27222

"ENV TERM xterm" only works if the container is created with .Tty = true.  Since we don't do this, the terminal emulation when we attach to a running container becomes "dumb".  Explicitly setting the TERM environment variable in /root/.bashrc fixes this.